### PR TITLE
Add PHPUnit workflow and basic login tests

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -25,7 +25,6 @@ jobs:
             composer install
           fi
 
-      - name: Ejecutar pruebas (simulado)
+      - name: Ejecutar PHPUnit
         run: |
-          echo "Aquí irían las pruebas automatizadas"
-          echo "Login probado correctamente"
+          phpunit --configuration phpunit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.phpunit.result.cache

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true" verbose="true" bootstrap="tests/bootstrap.php">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/LoginTest.php
+++ b/tests/LoginTest.php
@@ -1,0 +1,49 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class LoginTest extends TestCase
+{
+    private function resetSession()
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_unset();
+            session_destroy();
+        }
+        $_SESSION = [];
+        $_GET = [];
+        $_POST = [];
+    }
+
+    public function testIsUserLoggedInReturnsTrueWhenStatusIsSet()
+    {
+        $this->resetSession();
+        $login = new Login();
+        $_SESSION['user_login_status'] = 1;
+        $this->assertTrue($login->isUserLoggedIn());
+    }
+
+    public function testIsUserLoggedInReturnsFalseByDefault()
+    {
+        $this->resetSession();
+        $login = new Login();
+        $this->assertFalse($login->isUserLoggedIn());
+    }
+
+    public function testDoLogoutClearsSessionAndAddsMessage()
+    {
+        $this->resetSession();
+        $login = new Login();
+        $_SESSION['user_login_status'] = 1;
+        $login->doLogout();
+        $this->assertArrayNotHasKey('user_login_status', $_SESSION);
+        $this->assertContains('Has sido desconectado.', $login->messages);
+    }
+
+    public function testLoginMissingUsernameAddsError()
+    {
+        $this->resetSession();
+        $_POST = ['login' => 1, 'user_password' => '123'];
+        $login = new Login();
+        $this->assertContains('Username field was empty.', $login->errors);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+// Prevent session_start warnings from PHPUnit output
+ob_start();
+
+// Load the Login class for tests
+require_once __DIR__ . '/../classes/login.php';


### PR DESCRIPTION
## Summary
- configure PHPUnit with a simple phpunit.xml
- add Login unit tests
- add bootstrap that suppresses session warnings
- run tests in GitHub Actions

## Testing
- `phpunit --configuration phpunit.xml --testdox`

------
https://chatgpt.com/codex/tasks/task_e_684b783f439c8324a4a7b95d77fb0797